### PR TITLE
chore: bump rustler and use rebar_rustler plugin

### DIFF
--- a/native/elmdb_nif/Cargo.toml
+++ b/native/elmdb_nif/Cargo.toml
@@ -8,6 +8,6 @@ name = "elmdb_nif"
 crate-type = ["cdylib"]
 
 [dependencies]
-rustler = "0.29"
+rustler = { version = "0.36.2", features = ["nif_version_2_16"] }
 lmdb = "0.8"
 lazy_static = "1.4"

--- a/rebar.config
+++ b/rebar.config
@@ -7,13 +7,8 @@
 {deps, []}.
 
 %% Plugins
-{plugins, [rebar3_rustler]}.
-
-
-%% Cargo configuration
-{cargo_opts, [
-    {src_dir, "native/elmdb_nif"},
-    {cargo_args, ["--release"]}
+{plugins, [
+    rebar3_rustler
 ]}.
 
 %% Build hooks
@@ -24,6 +19,31 @@
     {post, [
         {clean, {cargo, clean}}
     ]}
+]}.
+
+%% Cargo configuration
+{cargo_opts, [
+    {src_dir, "native/elmdb_nif"},
+    {cargo_args, ["--release"]}
+]}.
+
+%% Pre/Post compile hooks
+{pre_hooks, [
+    {compile, "mkdir -p priv/"}
+]}.
+
+{post_hooks, [
+    {"(linux|darwin|solaris|freebsd)", compile, 
+     "sh -c 'find priv/crates -name \"libelmdb_nif.*\" -o -name \"elmdb_nif.*\" | head -1 | xargs -I {} cp {} priv/ && "
+     "cd priv && "
+     "for ext in so dylib; do "
+     "  if [ -f libelmdb_nif.$ext ]; then "
+     "    ln -sf libelmdb_nif.$ext elmdb_nif.so 2>/dev/null || true; "
+     "    ln -sf libelmdb_nif.$ext libelmdb_nif.so 2>/dev/null || true; "
+     "  fi; "
+     "done'"},
+    {"win32", compile, 
+     "powershell -Command \"Copy-Item -Path 'native\\elmdb_nif\\target\\release\\elmdb_nif.dll' -Destination 'priv\\' -Force\""}
 ]}.
 
 %% Test configuration
@@ -43,7 +63,7 @@
 ]}.
 
 %% Coverage analysis
-{cover_enabled, false}.
+{cover_enabled, true}.
 {cover_opts, [verbose]}.
 
 %% Profiles for different build configurations

--- a/rebar.config
+++ b/rebar.config
@@ -7,8 +7,13 @@
 {deps, []}.
 
 %% Plugins
-{plugins, [
-    {rebar3_cargo, "0.1.1"}
+{plugins, [rebar3_rustler]}.
+
+
+%% Cargo configuration
+{cargo_opts, [
+    {src_dir, "native/elmdb_nif"},
+    {cargo_args, ["--release"]}
 ]}.
 
 %% Build hooks
@@ -19,31 +24,6 @@
     {post, [
         {clean, {cargo, clean}}
     ]}
-]}.
-
-%% Cargo configuration
-{cargo_opts, [
-    {src_dir, "native/elmdb_nif"},
-    {cargo_args, ["--release"]}
-]}.
-
-%% Pre/Post compile hooks
-{pre_hooks, [
-    {compile, "mkdir -p priv/"}
-]}.
-
-{post_hooks, [
-    {"(linux|darwin|solaris|freebsd)", compile, 
-     "sh -c 'find native/elmdb_nif/target -name \"libelmdb_nif.*\" -type f ! -path \"*/deps/*\" | head -1 | xargs -I {} cp {} priv/ && "
-     "cd priv && "
-     "for ext in so dylib; do "
-     "  if [ -f libelmdb_nif.$ext ]; then "
-     "    ln -sf libelmdb_nif.$ext elmdb_nif.so 2>/dev/null || true; "
-     "    ln -sf libelmdb_nif.$ext libelmdb_nif.so 2>/dev/null || true; "
-     "  fi; "
-     "done'"},
-    {"win32", compile, 
-     "powershell -Command \"Copy-Item -Path 'native\\elmdb_nif\\target\\release\\elmdb_nif.dll' -Destination 'priv\\' -Force\""}
 ]}.
 
 %% Test configuration
@@ -63,7 +43,7 @@
 ]}.
 
 %% Coverage analysis
-{cover_enabled, true}.
+{cover_enabled, false}.
 {cover_opts, [verbose]}.
 
 %% Profiles for different build configurations

--- a/rebar.config
+++ b/rebar.config
@@ -8,7 +8,7 @@
 
 %% Plugins
 {plugins, [
-    rebar3_rustler
+    {rebar3_cargo, "0.1.1"}
 ]}.
 
 %% Build hooks

--- a/src/elmdb.erl
+++ b/src/elmdb.erl
@@ -15,7 +15,7 @@
 -export([db_open/2, db_close/1]).
 
 %% Key-value operations
--export([put/3, get/2, flush/1]).
+-export([put/3, put_batch/2, get/2, flush/1]).
 
 %% List operations
 -export([list/2]).
@@ -142,6 +142,16 @@ db_close(_DBInstance) ->
 put(_DBInstance, _Key, _Value) ->
     erlang:nif_error(nif_not_loaded).
 
+%% @doc Write multiple key-value pairs to the database in a single transaction
+%% @param DBInstance Database handle
+%% @param KeyValuePairs List of {Key, Value} tuples where Key and Value are binaries
+%% @returns ok on success, or {ok, SuccessCount, Errors} if some writes failed
+%% @throws {error, Type, Description} on failure
+-spec put_batch(DBInstance :: term(), KeyValuePairs :: [{binary(), binary()}]) -> 
+    ok | {ok, integer(), list()} | {error, term(), binary()}.
+put_batch(_DBInstance, _KeyValuePairs) ->
+    erlang:nif_error(nif_not_loaded).
+ 
 %% @doc Read a value by key from the database
 %% @param DBInstance Database handle
 %% @param Key The key to read (binary)
@@ -151,10 +161,6 @@ put(_DBInstance, _Key, _Value) ->
 get(_DBInstance, _Key) ->
     erlang:nif_error(nif_not_loaded).
 
-%% @private
-%% Internal function used by put/3
-put_batch(_DBInstance, _KeyValuePairs) ->
-    erlang:nif_error(nif_not_loaded).
 
 %%%===================================================================
 %%% List Operations


### PR DESCRIPTION
- Bumps rustler to latest version
- Sets features for OTP26+
- `rebar_rustler` plugin is not used because it does not copy the shared lib to `priv` (so this PR fixes the find/copy file)
 
Test results on HyperBEAM:
```
===> Performing EUnit tests...
======================== EUnit ========================
module 'hb_store_lmdb'
  hb_store_lmdb: basic_test...[0.179 s] ok
  hb_store_lmdb: list_test...[0.009 s] ok
  hb_store_lmdb: group_test...[0.008 s] ok
  hb_store_lmdb: link_test...[0.008 s] ok
  hb_store_lmdb: link_fragment_test...[0.008 s] ok
  hb_store_lmdb: type_test...[0.008 s] ok
  hb_store_lmdb: link_key_list_test...[0.008 s] ok
  hb_store_lmdb: path_traversal_link_test...[0.008 s] ok
  hb_store_lmdb: exact_hb_store_test...ok
  hb_store_lmdb: cache_style_test...[0.008 s] ok
  hb_store_lmdb: nested_map_cache_test...[0.020 s] ok
  hb_store_lmdb: cache_debug_test...[0.007 s] ok
  hb_store_lmdb: isolated_type_debug_test...[0.007 s] ok
  hb_store_lmdb: list_with_link_test...[0.008 s] ok
  [done in 0.328 s]
=======================================================
  All 14 tests passed.
```