### PR TITLE
feat: export a NIF function to match prefixes

### DIFF
--- a/native/elmdb_nif/src/lib.rs
+++ b/native/elmdb_nif/src/lib.rs
@@ -792,16 +792,18 @@ fn list<'a>(
         return Ok((atoms::error(), atoms::database_error(), error_msg).encode(env));
     }
     
-    let prefix_bytes = key_prefix.as_slice();
-    
     // Only flush write buffer if there are pending writes
     if db_handle.has_pending_writes() {
         if let Err(error_msg) = db_handle.force_flush_buffer() {
             return Ok((atoms::error(), atoms::transaction_error(), error_msg).encode(env));
         }
     }
-    
-    // Create a read-only transaction
+
+    // Return not_found if key_prefix is empty
+    if key_prefix.is_empty() {
+        return Ok(atoms::not_found().encode(env));
+    }
+
     let txn = match (*db_handle).env.env.begin_ro_txn() {
         Ok(txn) => txn,
         Err(_) => {
@@ -816,30 +818,21 @@ fn list<'a>(
             return Ok((atoms::error(), atoms::database_error(), "Failed to open cursor".to_string()).encode(env));
         }
     };
-    
+
+    // Check if cursor is positioned at the prefix
+    let prefix_bytes = key_prefix.as_slice();
+    if cursor.get(Some(prefix_bytes), None, MDB_SET_RANGE).is_err() {
+        return Ok(atoms::not_found().encode(env));
+    }
     // OPTIMIZATION: Use Vec instead of HashSet for better performance with small collections
     // Pre-allocate with reasonable capacity to avoid reallocations
     let mut children = Vec::with_capacity(64);
     let prefix_len = prefix_bytes.len();
     
     // OPTIMIZATION: Start cursor at prefix position instead of scanning from beginning
-    // This dramatically reduces iterations for sparse data
-    
-    // Safe iteration approach that handles empty databases and missing prefixes
-    // First, try to position cursor at prefix using MDB_SET_RANGE to check if key exists
-    // First, try to position cursor at prefix using MDB_SET_RANGE to check if key exists
-    let cursor_positioned = cursor.get(Some(prefix_bytes), None, MDB_SET_RANGE).is_ok();
-    
-    if !cursor_positioned {
-        // No keys >= prefix exist, return not_found immediately
-        return Ok(atoms::not_found().encode(env));
-    }
-    
     // Keys exist that are >= prefix, now safely use iter_from
-    let cursor_iter = cursor.iter_from(prefix_bytes);
-    
     // Iterate through keys starting from the prefix
-    for (key, _value) in cursor_iter {
+    for (key, _value) in cursor.iter_from(prefix_bytes) {
         
         // OPTIMIZATION: Early termination - if key doesn't start with prefix and we've already
         // found matches, we can break since keys are sorted
@@ -919,7 +912,69 @@ fn list<'a>(
 }
 
 #[rustler::nif]
-fn match_pattern<'a>(
+fn match_prefix<'a>(
+    env: Env<'a>,
+    db_handle: ResourceArc<LmdbDatabase>,
+    key_prefix: Binary
+) -> NifResult<Term<'a>> {
+    // Validate database and environment status
+    if let Err(error_msg) = db_handle.validate_database() {
+        return Ok((atoms::error(), atoms::database_error(), error_msg).encode(env));
+    }
+
+    // Return not_found if key_prefix is empty
+    if key_prefix.is_empty() {
+        return Ok(atoms::not_found().encode(env));
+    }
+
+    let mut matching_keys: Vec<Vec<u8>> = Vec::new();
+    let prefix_bytes = key_prefix.as_slice();
+    let txn = match (*db_handle).env.env.begin_ro_txn() {
+        Ok(txn) => txn,
+        Err(_) => {
+            return Ok((atoms::error(), atoms::transaction_error(), "Failed to begin read transaction".to_string()).encode(env));
+        }
+    };
+
+    let mut cursor = match txn.open_ro_cursor((*db_handle).db) {
+        Ok(cursor) => cursor,
+        Err(_) => {
+            return Ok((atoms::error(), atoms::database_error(), "Failed to open cursor".to_string()).encode(env));
+        }
+    };
+
+    // Check if cursor is positioned at the prefix
+    if cursor.get(Some(prefix_bytes), None, MDB_SET_RANGE).is_err() {
+        return Ok(atoms::not_found().encode(env));
+    }
+
+    // Iterate through keys starting from the prefix
+    for (key_bytes, _value) in cursor.iter_from(prefix_bytes) {
+        if !key_bytes.starts_with(prefix_bytes) {
+            break;
+        } else {
+            matching_keys.push(key_bytes.to_vec());
+        }
+    }
+
+    // Return results
+    if matching_keys.is_empty() {
+        Ok(atoms::not_found().encode(env))
+    } else {
+        // Convert matching keys to Erlang binaries
+        let mut keys_list = Vec::with_capacity(matching_keys.len());
+        for key in matching_keys {
+            let mut binary = OwnedBinary::new(key.len()).ok_or(Error::BadArg)?;
+            binary.clone_from_slice(&key);
+            keys_list.push(binary.release(env));
+        }
+
+        Ok((atoms::ok(), keys_list).encode(env))
+    }
+}
+
+#[rustler::nif]
+fn match_suffixes<'a>(
     env: Env<'a>,
     db_handle: ResourceArc<LmdbDatabase>,
     patterns: Vec<(Binary, Binary)>
@@ -946,23 +1001,21 @@ fn match_pattern<'a>(
             return Ok((atoms::error(), atoms::transaction_error(), error_msg).encode(env));
         }
     }
-    
-    // Create a read-only transaction
+        
     let txn = match (*db_handle).env.env.begin_ro_txn() {
         Ok(txn) => txn,
         Err(_) => {
             return Ok((atoms::error(), atoms::transaction_error(), "Failed to begin read transaction".to_string()).encode(env));
         }
     };
-    
-    // Open a cursor for the database
+
     let mut cursor = match txn.open_ro_cursor((*db_handle).db) {
         Ok(cursor) => cursor,
         Err(_) => {
             return Ok((atoms::error(), atoms::database_error(), "Failed to open cursor".to_string()).encode(env));
         }
     };
-    
+
     // Data structures for tracking matches
     const MAX_RESULTS: usize = 100000;  // Reasonable limit to prevent unbounded memory growth
     let mut matching_ids: Vec<Vec<u8>> = Vec::new();
@@ -976,7 +1029,7 @@ fn match_pattern<'a>(
         // Parse key to extract ID and suffix
         // Find the position of the last '/' to extract the ID and suffix
         let last_slash_pos = key_bytes.iter().rposition(|&b| b == b'/');
-        
+
         let (id, suffix) = if let Some(pos) = last_slash_pos {
             // Has hierarchy - split into ID and suffix
             let id = key_bytes[..pos].to_vec();
@@ -1026,15 +1079,14 @@ fn match_pattern<'a>(
         Ok(atoms::not_found().encode(env))
     } else {
         // Convert matching IDs to Erlang binaries
-        let mut result_binaries = Vec::with_capacity(matching_ids.len());
+        let mut ids_list = Vec::with_capacity(matching_ids.len());
         for id in matching_ids {
-            let mut binary = OwnedBinary::new(id.len())
-                .ok_or(Error::BadArg)?;
-            binary.as_mut_slice().copy_from_slice(&id);
-            result_binaries.push(binary.release(env));
+            let mut binary = OwnedBinary::new(id.len()).ok_or(Error::BadArg)?;
+            binary.clone_from_slice(&id);
+            ids_list.push(binary.release(env));
         }
-        
-        Ok((atoms::ok(), result_binaries).encode(env))
+
+        Ok((atoms::ok(), ids_list).encode(env))
     }
 }
 

--- a/src/elmdb.erl
+++ b/src/elmdb.erl
@@ -209,10 +209,10 @@ match_prefix(_DBInstance, _Patterns) ->
 -spec match(DBInstance :: term(), Patterns :: [{binary(), binary()}]) -> 
     {ok, [binary()]} | not_found | {error, term(), binary()}.
 match(DBInstance, Patterns) ->
-    match_suffixes(DBInstance, Patterns).
+    match_pattern(DBInstance, Patterns).
 
-%% Internal NIF stub for match_suffixes
-match_suffixes(_DBInstance, _Patterns) ->
+%% Internal NIF stub for match_pattern
+match_pattern(_DBInstance, _Patterns) ->
     erlang:nif_error(nif_not_loaded).
 
 %% @doc Explicitly flush any buffered writes to disk

--- a/src/elmdb.erl
+++ b/src/elmdb.erl
@@ -21,7 +21,7 @@
 -export([list/2]).
 
 %% Pattern matching operations
--export([match/2]).
+-export([match_prefix/2, match/2]).
 
 
 %% NIF loading
@@ -189,6 +189,11 @@ list(_DBInstance, _Key) ->
 %%% Pattern Matching Operations
 %%%===================================================================
 
+-spec match_prefix(DBInstance :: term(), Pattern :: binary()) -> 
+    {ok, [binary()]} | not_found | {error, term(), binary()}.
+match_prefix(_DBInstance, _Patterns) ->
+    erlang:nif_error(nif_not_loaded).
+
 %% @doc Match database entries against a set of key-value patterns
 %% @param DBInstance Database handle
 %% @param Patterns List of {KeySuffix, Value} tuples to match against
@@ -204,10 +209,10 @@ list(_DBInstance, _Key) ->
 -spec match(DBInstance :: term(), Patterns :: [{binary(), binary()}]) -> 
     {ok, [binary()]} | not_found | {error, term(), binary()}.
 match(DBInstance, Patterns) ->
-    match_pattern(DBInstance, Patterns).
+    match_suffixes(DBInstance, Patterns).
 
-%% Internal NIF stub for match_pattern
-match_pattern(_DBInstance, _Patterns) ->
+%% Internal NIF stub for match_suffixes
+match_suffixes(_DBInstance, _Patterns) ->
     erlang:nif_error(nif_not_loaded).
 
 %% @doc Explicitly flush any buffered writes to disk


### PR DESCRIPTION
## Why

In the context of `hb_store:sync` (FOR-139) we need to be able to list the groups in order to sync (copy the entries) from one LMDB to another. It enables the fix of `hb_store:list(LmdbOpts, "/")` by supporting `elmdb:match_prefix(DBHandle, <<"group:">>)` 

## What

This PR provides a `match_prefix` NIF function that will be used to list all groups once they are indexed with the group: prefix.