### PR TITLE
chore: bump LMDB via lmdb-master-sys

### DIFF
--- a/native/elmdb_nif/Cargo.toml
+++ b/native/elmdb_nif/Cargo.toml
@@ -9,5 +9,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 rustler = { version = "0.36.2", features = ["nif_version_2_16"] }
-lmdb = "0.8"
+lmdb = { git = "https://github.com/permaweb/lmdb-master-rs.git" }
 lazy_static = "1.4"


### PR DESCRIPTION
Written data is consistent after restarting HyperBEAM and reading it again.
The validation steps below make use of the `elmdb:iterator_start` and `elmdb:iterator_cont` implemented at https://github.com/twilson63/elmdb-rs/pull/12

<img width="1370" height="878" alt="image" src="https://github.com/user-attachments/assets/1f2b3a42-1ce1-4ad4-8452-c61a9f96c811" />
<img width="1330" height="510" alt="image" src="https://github.com/user-attachments/assets/cf1aafd0-8f9c-41a0-9106-dc2c790d5908" />

PS: For the first two rounds the size and content of the iterations were validated as well (the Cont comes from previous iteration).