### PR TITLE
impr: Add environment error information details

### DIFF
--- a/native/elmdb_nif/src/lib.rs
+++ b/native/elmdb_nif/src/lib.rs
@@ -240,13 +240,14 @@ fn env_open<'a>(env: Env<'a>, path: Term<'a>, options: Vec<Term<'a>>) -> NifResu
                             lmdb::Error::Corrupted => atoms::corrupted(),
                             lmdb::Error::VersionMismatch => atoms::version_mismatch(),
                             lmdb::Error::MapFull => atoms::map_full(),
-                            _ => atoms::environment_error()
+                            lmdb::Error::Other(24) => return Ok((atoms::error(), (atoms::environment_error(), "Too many open files".to_string())).encode(env)),
+                            other => return Ok((atoms::error(), (atoms::environment_error(), format!("{:?}", other))).encode(env)),
                         }
                     },
                     Err(io_err) => {
                         match io_err.kind() {
                             std::io::ErrorKind::PermissionDenied => atoms::permission_denied(),
-                            _ => atoms::environment_error()
+                            other => return Ok((atoms::error(), (atoms::environment_error(), format!("{:?}", other))).encode(env)),
                         }
                     }
                 }


### PR DESCRIPTION
Currently, in some cases that return the tuple `{error, environment_error}`, we don't have extra information for it. 

This adds generic error information, and also handles error 24, too many open files.