### PR TITLE
Add GitHub Actions CI (clippy + eunit, OTP 24-27)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    name: OTP ${{ matrix.otp }}
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      # rebar3 pinned per OTP: 3.24 requires OTP 25+, 3.22 is the last line
+      # supporting OTP 24.
+      matrix:
+        include:
+          - otp: '24.3'
+            rebar3: '3.22.1'
+          - otp: '25'
+            rebar3: '3.23.0'
+          - otp: '26'
+            rebar3: '3.24.0'
+          - otp: '27'
+            rebar3: '3.24.0'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{ matrix.otp }}
+          rebar3-version: ${{ matrix.rebar3 }}
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: native/elmdb_nif
+
+      - name: Rust lint (clippy)
+        run: cargo clippy --release --manifest-path native/elmdb_nif/Cargo.toml
+
+      - name: EUnit tests
+        run: rebar3 eunit


### PR DESCRIPTION
## Summary

Adds the repository's first CI workflow: `cargo clippy` plus the full 82-test EUnit suite on every pull request and every push to `main`, across the OTP versions the README claims support for (24, 25, 26, 27).

Details:
- ubuntu-22.04 runners (hex.pm publishes prebuilt OTP 24 binaries for 22.04; 24.04 only carries newer OTPs)
- rebar3 pinned per OTP row — rebar3 3.24 dropped OTP 24 support, so 24.3 pairs with 3.22.1
- Rust dependency caching per matrix entry via Swatinem/rust-cache
- `fail-fast: false` so one OTP failure doesn't mask results on the others

Once merged, #19 (the lmdb→heed migration) and all future PRs get green/red checks instead of relying on locally-run test claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RV52tmdZEU1pMEfpKcjKHc